### PR TITLE
Add COMET evaluation

### DIFF
--- a/data.py
+++ b/data.py
@@ -197,6 +197,11 @@ def get_flores_dataset_path(dataset="dev"):
 
     return flores_dataset
 
+def get_flores_file_path(lang_code, dataset="dev"):
+    flores_dataset = get_flores_dataset_path(dataset)
+    flores_file_path = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")
+    return flores_file_path
+
 def get_flores(lang_code, dataset="dev"):
     flores_dataset = get_flores_dataset_path(dataset)
     source = os.path.join(flores_dataset, nllb_langs[lang_code] + f".{dataset}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sentencepiece==0.1.99
 requests==2.31.0
 PyYAML==6.0.1
 sacrebleu==2.3.1
-unbabael-comet==2.2.2
+unbabel-comet==2.2.2
 subword-nmt>=0.3.7
 OpenNMT-py==3.4.1
 tensorboard==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ sentencepiece==0.1.99
 requests==2.31.0
 PyYAML==6.0.1
 sacrebleu==2.3.1
+unbabael-comet==2.2.2
 subword-nmt>=0.3.7
 OpenNMT-py==3.4.1
 tensorboard==2.14.0


### PR DESCRIPTION
- In requirements.txt, include COMET (2.2.2)
- In data.py add a method for flores200 file path retrieval
In eval.py :
- add a "--comet" option for running COMET evaluation
- Runs a translation of source flores200 file corresponding to specified configuration and dataset 
- than runs COMET for evaluation on said file, source, and reference (target language) flores200 files

Having COMET installed also allows for command line "comet-compare" comparison of models.